### PR TITLE
Add keyboard-driven game loop with demo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ features = [
 	"Event",
 	"Response",
 	"Performance",
+	"KeyboardEvent",
 ]
 
 [dependencies.serde]

--- a/src/brwsr.rs
+++ b/src/brwsr.rs
@@ -1,9 +1,6 @@
 use crate::JRslt;
 pub use anyhow::Result as Rslt;
 use anyhow::anyhow;
-use serde::Deserialize;
-use serde::de::DeserializeOwned;
-use std::collections::HashMap;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::closure::IntoWasmClosure;

--- a/src/engn.rs
+++ b/src/engn.rs
@@ -9,15 +9,20 @@ use crate::brwsr::raf_closure;
 use crate::brwsr::request_animation_frame;
 use anyhow::Context;
 use anyhow::anyhow;
+use futures::channel::mpsc::UnboundedReceiver;
+use futures::channel::mpsc::unbounded;
 use futures::channel::oneshot::Canceled;
 use serde::Deserialize;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::ops::Add;
+use std::ops::AddAssign;
 use std::rc::Rc;
 use std::sync::Mutex;
 use wasm_bindgen::JsCast;
 use web_sys::Event;
 use web_sys::HtmlImageElement;
+use web_sys::KeyboardEvent;
 
 /// path to sprite sheet
 const SPRITE_SHEET: &str = "rhb.png";
@@ -48,8 +53,7 @@ impl Renderer {
 		&self,
 		img: &Image,
 		name: &str,
-		x: f64,
-		y: f64,
+		pos: Point,
 	) -> Rslt<(),> {
 		let frame = &img
 			.sprite_sheet_mapper
@@ -63,8 +67,8 @@ impl Renderer {
 			&img.image,
 			frame.x_f64(),
 			frame.y_f64(),
-			x,
-			y,
+			pos.x_into(),
+			pos.y_into(),
 			frame.w_f64(),
 			frame.h_f64(),
 		)
@@ -81,9 +85,9 @@ pub struct Image {
 }
 
 impl Image {
-	pub async fn new(src: &str,) -> Rslt<Self,> {
+	pub async fn new() -> Rslt<Self,> {
 		let image = new_image()?;
-		load(&image, src,).await??;
+		// load(&image, src,).await??;
 		Ok(Self { image, sprite_sheet_mapper: None, },)
 	}
 
@@ -98,6 +102,11 @@ impl Image {
 	pub async fn set_sprite_sheet(&mut self,) -> Rslt<&Self,> {
 		self.sprite_sheet_mapper = Some(sprite_sheet_mapper().await?,);
 		load(&self.image, SPRITE_SHEET,).await??;
+		Ok(self,)
+	}
+
+	pub async fn load(&self, src: &str,) -> Rslt<&Self,> {
+		load(&self.image, src,).await??;
 		Ok(self,)
 	}
 }
@@ -191,35 +200,37 @@ async fn load(
 }
 
 pub trait Game: std::marker::Sized {
-	async fn init(&self,) -> Rslt<Self,>;
-	fn update(&mut self,);
-	fn draw(&self, rndr: &Renderer,);
+	async fn init(&mut self,) -> Rslt<(),>;
+	fn update(&mut self, kb_state: &KeyboardState,);
+	fn draw(&self,);
 }
 
-struct GameLoop {
+pub struct GameLoop {
 	last_frame:        f64,
 	accumulated_delta: f32,
 }
 
 impl GameLoop {
-	pub async fn start(game: impl Game + 'static,) -> Rslt<(),> {
-		let mut game = game.init().await?;
+	pub async fn start(mut game: impl Game + 'static,) -> Rslt<(),> {
+		let mut kbe_rx = prepare_input()?;
+		game.init().await?;
 		let mut game_loop =
 			Self { last_frame: brwsr::now()?, accumulated_delta: 0.0, };
 
-		let rndrr = Renderer::new("game_canvas",).await?;
 		let f = Rc::new(RefCell::new(None,),);
 		let g = f.clone();
 
+		let mut kb_stat = KeyboardState::new();
 		*f.borrow_mut() = Some(raf_closure(move |perf| {
+			kb_stat.process_input(&mut kbe_rx,);
 			game_loop.accumulated_delta += (perf - game_loop.last_frame) as f32;
 
 			while game_loop.accumulated_delta > FRAME_SIZE {
-				game.update();
+				game.update(&kb_stat,);
 				game_loop.accumulated_delta -= FRAME_SIZE;
 			}
 			game_loop.last_frame = perf;
-			game.draw(&rndrr,);
+			game.draw();
 			request_animation_frame(g.borrow().as_ref().unwrap(),)
 				.unwrap_or_else(|e| {
 					panic!(
@@ -234,5 +245,113 @@ impl GameLoop {
 		)?;
 
 		Ok((),)
+	}
+}
+
+#[derive(Debug,)]
+enum KeyState {
+	Up(KeyboardEvent,),
+	Down(KeyboardEvent,),
+}
+
+fn prepare_input() -> Rslt<UnboundedReceiver<KeyState,>,> {
+	let (tx, rx,) = unbounded();
+	let keydown_tx = Rc::new(RefCell::new(tx,),);
+	let keyup_tx = keydown_tx.clone();
+
+	let onkeydown = brwsr::closure_new::<_, dyn FnMut(KeyboardEvent,),>(
+		move |kbe: KeyboardEvent| {
+			keydown_tx
+				.borrow_mut()
+				.start_send(KeyState::Down(kbe,),)
+				.expect("failed to send keydown state",);
+		},
+	);
+	let onkeyup = brwsr::closure_new::<_, dyn FnMut(KeyboardEvent,),>(
+		move |kbe: KeyboardEvent| {
+			keyup_tx
+				.borrow_mut()
+				.start_send(KeyState::Up(kbe,),)
+				.expect("failed to send keyup state",);
+		},
+	);
+
+	let canvas = get_canvas_element("game_canvas",)?;
+	canvas.set_onkeyup(Some(onkeyup.as_ref().unchecked_ref(),),);
+	onkeyup.forget();
+	canvas.set_onkeydown(Some(onkeydown.as_ref().unchecked_ref(),),);
+	onkeydown.forget();
+
+	Ok(rx,)
+}
+
+pub struct KeyboardState {
+	pressed_keys: HashMap<String, KeyboardEvent,>,
+}
+
+impl KeyboardState {
+	fn new() -> Self {
+		Self { pressed_keys: HashMap::new(), }
+	}
+
+	pub fn is_pressed(&self, code: &str,) -> bool {
+		self.pressed_keys.contains_key(code,)
+	}
+
+	fn set_pressed(&mut self, code: &str, event: KeyboardEvent,) {
+		self.pressed_keys.insert(code.into(), event,);
+	}
+
+	fn set_released(&mut self, code: &str,) {
+		self.pressed_keys.remove(code,);
+	}
+
+	fn process_input(&mut self, kbe_rx: &mut UnboundedReceiver<KeyState,>,) {
+		loop {
+			match kbe_rx.try_next() {
+				Ok(Some(KeyState::Down(event,),),) => {
+					self.set_pressed(&event.code(), event,)
+				},
+				Ok(Some(KeyState::Up(event,),),) => {
+					self.set_released(&event.code(),)
+				},
+				_ => {
+					// log!("prsd kys: {:?}", self.pressed_keys);
+					break;
+				},
+			}
+		}
+	}
+}
+
+#[derive(Clone, Copy,)]
+pub struct Point {
+	pub x: i16,
+	pub y: i16,
+}
+
+impl Point {
+	pub fn x_into(&self,) -> f64 {
+		self.x.into()
+	}
+
+	pub fn y_into(&self,) -> f64 {
+		self.y.into()
+	}
+}
+
+impl Add for Point {
+	type Output = Self;
+
+	fn add(mut self, rhs: Self,) -> Self::Output {
+		self += rhs;
+		self
+	}
+}
+
+impl AddAssign for Point {
+	fn add_assign(&mut self, rhs: Self,) {
+		self.x += rhs.x;
+		self.y += rhs.y;
 	}
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,0 +1,69 @@
+use crate::Rslt;
+use crate::engn::Game;
+use crate::engn::Image;
+use crate::engn::KeyboardState;
+use crate::engn::Point;
+use crate::engn::Renderer;
+
+pub struct WalkTheDog {
+	renderer: Option<Renderer,>,
+	image:    Option<Image,>,
+	pos:      Point,
+	frame:    u8,
+}
+
+impl WalkTheDog {
+	pub fn new() -> Self {
+		Self {
+			renderer: None,
+			image:    None,
+			pos:      Point { x: 0, y: 0, },
+			frame:    0,
+		}
+	}
+}
+
+impl Game for WalkTheDog {
+	async fn init(&mut self,) -> Rslt<(),> {
+		self.renderer = Some(Renderer::new("game_canvas",).await?,);
+		self.image = Some(Image::new_sprite_sheet().await?,);
+		Ok((),)
+	}
+
+	fn update(&mut self, kb_stat: &KeyboardState,) {
+		if self.frame < 23 {
+			self.frame += 1;
+		} else {
+			self.frame = 0;
+		}
+
+		let mut vel = Point { x: 0, y: 0, };
+		let pressed = |code| kb_stat.is_pressed(code,);
+		if pressed("KeyA",) {
+			vel.x -= 3;
+		}
+		if pressed("KeyS",) {
+			vel.y += 3;
+		}
+		if pressed("KeyD",) {
+			vel.y -= 3;
+		}
+		if pressed("KeyF",) {
+			vel.x += 3;
+		}
+
+		self.pos += vel;
+	}
+
+	fn draw(&self,) {
+		let frame_name = format!("Run ({}).png", (self.frame / 3) + 1);
+
+		if let Some(r,) = self.renderer.as_ref() {
+			r.clear();
+			if let Some(img,) = self.image.as_ref() {
+				r.draw_sprite_sheet(img, &frame_name, self.pos,)
+					.expect("failed to draw sheet",);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- refactor the engine to handle keyboard input and positional points
- add a simple WalkTheDog game loop that renders a sprite sheet
- hook the wasm entrypoint to start the new game loop

## Testing
- nix develop --command cargo check
