### PR TITLE
Refactor Red Hat Boy animation into state machine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "js-sys"
 version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +297,7 @@ dependencies = [
  "rand",
  "serde",
  "serde-wasm-bindgen",
+ "strum",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -365,6 +372,27 @@ name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,10 @@ version = "*"
 [dependencies.wasm-bindgen-futures]
 version = "*"
 
+[dependencies.strum]
+version = "*"
+features = ["derive"]
+
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so it's only enabled

--- a/examples/strum.rs
+++ b/examples/strum.rs
@@ -1,0 +1,23 @@
+#[derive(strum::Display,)]
+enum QwQ {
+	A,
+	B(String,),
+	#[strum(to_string = "C has {x}")]
+	C {
+		x: i32,
+	},
+	#[strum(to_string = "technically, E")]
+	D,
+}
+
+fn main() {
+	let a = QwQ::A;
+	let b = QwQ::B("wth".to_string(),);
+	let c = QwQ::C { x: 666, };
+	let d = QwQ::D;
+
+	println!("a: {a}");
+	println!("b: {b}");
+	println!("c: {c}");
+	println!("d: {d}");
+}

--- a/src/game.rs
+++ b/src/game.rs
@@ -4,66 +4,180 @@ use crate::engn::Image;
 use crate::engn::KeyboardState;
 use crate::engn::Point;
 use crate::engn::Renderer;
+use crate::game::red_hat_boy_states::Idle;
+use crate::game::red_hat_boy_states::RedHatBoyState;
+use crate::game::red_hat_boy_states::Running;
+
+mod red_hat_boy_states;
+
+/// count of idle cards
+const IDLE_CARDS: u8 = 10;
+/// count of running cards
+const RUN_CARDS: u8 = 8;
+const WALK_SPEED: i16 = 3;
 
 pub struct WalkTheDog {
 	renderer: Option<Renderer,>,
-	image:    Option<Image,>,
-	pos:      Point,
-	frame:    u8,
+	rhb:      Option<RedHatBoy,>,
 }
 
 impl WalkTheDog {
 	pub fn new() -> Self {
-		Self {
-			renderer: None,
-			image:    None,
-			pos:      Point { x: 0, y: 0, },
-			frame:    0,
-		}
+		Self { renderer: None, rhb: None, }
 	}
 }
 
 impl Game for WalkTheDog {
 	async fn init(&mut self,) -> Rslt<(),> {
 		self.renderer = Some(Renderer::new("game_canvas",).await?,);
-		self.image = Some(Image::new_sprite_sheet().await?,);
+
+		let image = Image::new_sprite_sheet().await?;
+
+		self.rhb = Some(RedHatBoy::new(image,)?,);
 		Ok((),)
 	}
 
-	fn update(&mut self, kb_stat: &KeyboardState,) {
-		if self.frame < 23 {
-			self.frame += 1;
-		} else {
-			self.frame = 0;
-		}
+	fn update(&mut self, kb_state: &KeyboardState,) {
+		let Some(ref mut rhb,) = self.rhb else {
+			return;
+		};
 
-		let mut vel = Point { x: 0, y: 0, };
-		let pressed = |code| kb_stat.is_pressed(code,);
-		if pressed("KeyA",) {
-			vel.x -= 3;
-		}
-		if pressed("KeyS",) {
-			vel.y += 3;
-		}
-		if pressed("KeyD",) {
-			vel.y -= 3;
-		}
-		if pressed("KeyF",) {
-			vel.x += 3;
-		}
-
-		self.pos += vel;
+		rhb.update(kb_state,);
 	}
 
 	fn draw(&self,) {
-		let frame_name = format!("Run ({}).png", (self.frame / 3) + 1);
+		let Some(ref rndrr,) = self.renderer else {
+			return;
+		};
+		rndrr.clear();
+		if let Some(rhb,) = self.rhb.as_ref() {
+			rhb.draw(rndrr,).expect("error happen while drawing rhb",);
+		}
+		// let frame_name = format!("Run ({}).png", (self.frame / 3) + 1);
+		//
+		// if let Some(r,) = self.renderer.as_ref() {
+		// 	r.clear();
+		// 	if let Some(RedHatBoy { image, .. },) = self.rhb.as_ref() {
+		// 		r.draw_sprite_sheet(image, &frame_name, self.pos,)
+		// 			.expect("failed to draw sheet",);
+		// 	}
+		// }
+	}
+}
 
-		if let Some(r,) = self.renderer.as_ref() {
-			r.clear();
-			if let Some(img,) = self.image.as_ref() {
-				r.draw_sprite_sheet(img, &frame_name, self.pos,)
-					.expect("failed to draw sheet",);
-			}
+struct RedHatBoy {
+	state_machine: RedHatBoyStateMachine,
+	image:         Image,
+}
+
+impl RedHatBoy {
+	fn new(image: Image,) -> Rslt<Self,> {
+		Ok(Self {
+			state_machine: RedHatBoyStateMachine::Idle(RedHatBoyState::new(),),
+			image,
+		},)
+	}
+
+	fn draw(&self, rndrr: &Renderer,) -> Rslt<(),> {
+		rndrr.draw_sprite_sheet(
+			&self.image,
+			&self.state_machine.frame_name(),
+			self.state_machine.context().pos,
+		)
+	}
+
+	fn update(&mut self, kb_state: &KeyboardState,) {
+		let vel = Self::keyboard_velocity(kb_state,);
+		let event = if vel.x == 0 && vel.y == 0 {
+			GameEvent::Idle
+		} else {
+			GameEvent::Run { vel, }
+		};
+
+		self.state_machine = self.state_machine.transition(event,);
+		self.state_machine = self.state_machine.update();
+	}
+
+	fn keyboard_velocity(kb_state: &KeyboardState,) -> Point {
+		let mut vel = Point { x: 0, y: 0, };
+		let pressed = |code| kb_state.is_pressed(code,);
+		if pressed("KeyA",) {
+			vel.x -= WALK_SPEED;
+		}
+		if pressed("KeyF",) {
+			vel.x += WALK_SPEED;
+		}
+		if pressed("KeyS",) {
+			vel.y += WALK_SPEED;
+		}
+		if pressed("KeyD",) {
+			vel.y -= WALK_SPEED;
+		}
+
+		vel
+	}
+}
+
+#[derive(Clone, Copy, strum::Display,)]
+enum RedHatBoyStateMachine {
+	Idle(RedHatBoyState<Idle,>,),
+	#[strum(to_string = "Run")]
+	Running(RedHatBoyState<Running,>,),
+}
+
+impl From<RedHatBoyState<Running,>,> for RedHatBoyStateMachine {
+	fn from(value: RedHatBoyState<Running,>,) -> Self {
+		Self::Running(value,)
+	}
+}
+
+#[derive(Clone, Copy,)]
+pub enum GameEvent {
+	Idle,
+	Run { vel: Point, },
+}
+
+impl RedHatBoyStateMachine {
+	fn transition(self, event: GameEvent,) -> Self {
+		match (self, event,) {
+			(Self::Idle(mut state,), GameEvent::Idle,) => {
+				state.reset();
+				Self::Idle(state,)
+			},
+			(Self::Idle(state,), GameEvent::Run { vel, },) => {
+				state.run(vel,).into()
+			},
+			(Self::Running(state,), GameEvent::Idle,) => {
+				Self::Idle(state.idle(),)
+			},
+			(Self::Running(state,), GameEvent::Run { vel, },) => {
+				Self::Running(state.with_velocity(vel,),)
+			},
+		}
+	}
+
+	fn frame_name(&self,) -> String {
+		let cur_card_count = (self.context().frame / 3) % self.card_count() + 1;
+		format!("{} ({cur_card_count}).png", self)
+	}
+
+	fn card_count(&self,) -> u8 {
+		match self {
+			Self::Idle(_,) => IDLE_CARDS,
+			Self::Running(_,) => RUN_CARDS,
+		}
+	}
+
+	fn update(self,) -> Self {
+		match self {
+			Self::Idle(mut red_hat_boy_state,) => {
+				red_hat_boy_state.update();
+				Self::Idle(red_hat_boy_state,)
+			},
+			Self::Running(mut red_hat_boy_state,) => {
+				red_hat_boy_state.update();
+				Self::Running(red_hat_boy_state,)
+			},
 		}
 	}
 }

--- a/src/game/red_hat_boy_states.rs
+++ b/src/game/red_hat_boy_states.rs
@@ -1,0 +1,84 @@
+use crate::engn::Point;
+use crate::game::RedHatBoyStateMachine;
+use std::marker::PhantomData;
+
+const FLOOR: i16 = 475;
+
+#[derive(Clone, Copy,)]
+pub(super) struct RedHatBoyState<S,> {
+	context: RedHatBoyContext,
+	#[doc(hidden)]
+	_state:  PhantomData<S,>,
+}
+
+impl<S,> RedHatBoyState<S,> {
+	pub(super) fn update(&mut self,) {
+		self.context.update();
+	}
+}
+
+#[derive(Clone, Copy,)]
+pub(super) struct RedHatBoyContext {
+	pub frame: u8,
+	pub pos:   Point,
+	pub vel:   Point,
+}
+
+impl RedHatBoyContext {
+	fn update(&mut self,) {
+		self.frame = self.frame.wrapping_add(1,);
+		self.pos += self.vel;
+	}
+}
+
+#[derive(Clone, Copy,)]
+pub(super) struct Idle;
+#[derive(Clone, Copy,)]
+pub(super) struct Running;
+
+impl RedHatBoyState<Idle,> {
+	pub fn new() -> Self {
+		Self {
+			context: RedHatBoyContext {
+				frame: 0,
+				pos:   Point { x: 0, y: FLOOR, },
+				vel:   Point { x: 0, y: 0, },
+			},
+			_state:  PhantomData,
+		}
+	}
+
+	pub fn run(self, vel: Point,) -> RedHatBoyState<Running,> {
+		let mut context = self.context;
+		context.frame = 0;
+		context.vel = vel;
+		RedHatBoyState { context, _state: PhantomData, }
+	}
+
+	pub fn reset(&mut self,) {
+		self.context.vel = Point { x: 0, y: 0, };
+	}
+}
+
+impl RedHatBoyState<Running,> {
+	pub fn with_velocity(mut self, vel: Point,) -> Self {
+		self.context.vel = vel;
+		self
+	}
+
+	pub fn idle(self,) -> RedHatBoyState<Idle,> {
+		let mut context = self.context;
+		context.frame = 0;
+		context.vel = Point { x: 0, y: 0, };
+		RedHatBoyState { context, _state: PhantomData, }
+	}
+}
+
+impl RedHatBoyStateMachine {
+	pub(super) fn context(&self,) -> &RedHatBoyContext {
+		match self {
+			Self::Idle(red_hat_boy_state,) => &red_hat_boy_state.context,
+			Self::Running(red_hat_boy_state,) => &red_hat_boy_state.context,
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add strum derive example showcasing strum::Display
- introduce RedHatBoy state machine to manage idle/run animations
- update WalkTheDog loop to drive state transitions and redraw cleanly

## Testing
- nix develop -c cargo check